### PR TITLE
Fix compatibility with gcc/g++ 4.7+

### DIFF
--- a/dtcc/main.cpp
+++ b/dtcc/main.cpp
@@ -22,6 +22,7 @@
 #include <AsmGenerator.h>
 #include <CompilerException.h>
 #include <argtable2.h>
+#include <unistd.h>
 
 extern "C"
 {


### PR DESCRIPTION
Added include <unistd.h> to fix compatibility issue with gcc/g++ versions 4.7 or higher.

fixes #147
